### PR TITLE
Make navbar dropdown white on mobile devices and clean up indentation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,80 +1,88 @@
 html {
-    min-width: 320px;
+  min-width: 320px;
 }
 .wrapper {
-    background: linear-gradient(
-        to bottom,
-        rgba(0, 200, 250, 1) 10%,
-        rgba(0, 80, 190, 1) 100%
-    );
-    min-height: 100%;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 200, 250, 1) 10%,
+    rgba(0, 80, 190, 1) 100%
+  );
+  min-height: 100%;
 }
 .wrapper_404 {
-    background: linear-gradient(
-        to bottom,
-        rgba(240, 20, 100, 1) 10%,
-        rgba(200, 140, 0, 1) 100%
-    );
+  background: linear-gradient(
+    to bottom,
+    rgba(240, 20, 100, 1) 10%,
+    rgba(200, 140, 0, 1) 100%
+  );
 }
 .gap-10 {
-    gap: 10px;
+  gap: 10px;
 }
 .gap-20 {
-    gap: 20px;
+  gap: 20px;
 }
 .w-85 {
-    width: 85%;
+  width: 85%;
 }
 .dropdown-item.active,
 .dropdown-item:active {
-    background: white;
-    color: black;
+  background: white;
+  color: black;
 }
 .rotate-180 {
-    transform: rotate(180deg);
+  transform: rotate(180deg);
 }
 
 /* ### header ###  */
 .header {
-    height: 77px;
+  height: 77px;
 }
 .header li button,
 .header li a {
-    color: white;
+  color: white;
 }
 .nav-link.active {
-    color: white !important;
+  color: white !important;
 }
 .dropdown-menu {
-    width: min-content;
-    min-width: 120px;
+  width: min-content;
+  min-width: 120px;
+}
+
+.navbar-toggler {
+  border-color: white;
+}
+
+.navbar-toggler-icon {
+  --bs-navbar-toggler-icon-bg: url("data:image/svg+xml;charset=UTF8,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
 }
 
 /* ### main ###  */
 .main {
-    flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 .promo__img {
-    width: 260px;
-    height: 260px;
+  width: 260px;
+  height: 260px;
 }
 .promo__text {
-    max-width: 650px;
+  max-width: 650px;
 }
 .promo__header {
-    font-size: 3.5rem;
+  font-size: 3.5rem;
 }
 .promo__descr {
-    font-size: 1.15rem;
+  font-size: 1.15rem;
 }
 .promo_win {
-    max-width: 800px;
+  max-width: 800px;
 }
 
 /* ### footer ###  */
 .footer {
-    background-color: rgba(0, 50, 80, 50);
+  background-color: rgba(0, 50, 80, 50);
 }
 .footer_404 {
-    background-color: rgba(100, 50, 40, 1);
+  background-color: rgba(100, 50, 40, 1);
 }


### PR DESCRIPTION
## What’s Changed
- Updated the dropdown CSS so that the logo displays in white for improved contrast on mobile.
- Ran Prettier across the CSS, which only removed extra indentation—no other functional or stylistic changes were introduced.

## Why
This change ensures it’s clearly visible without altering any layout or behavior apart from indentation cleanup.

## Verification
- Tested in Chrome’s device emulator at various widths (<768px and ≥768px).  
