### PR TITLE
fix: use root-relative paths for local assets, pages, and scripts

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,11 +5,11 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>DuckStation: 404!</title>
-	<link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicon32.png">
+	<link rel="icon" type="image/png" sizes="32x32" href="/assets/img/favicon32.png">
 	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
 		integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.2/font/bootstrap-icons.min.css">
-	<link href="styles.css" rel="stylesheet" />
+	<link href="/styles.css" rel="stylesheet" />
 </head>
 
 <body class="h-100">
@@ -17,11 +17,11 @@
 		<header class="header" data-block="header">
 			<nav class="navbar navbar-expand-md fixed-top w-100">
 				<div class="container px-lg-5">
-					<img class="navbar-brand me-lg-5" src="assets/img/duck_head.svg" alt="DuckStation">
+					<img class="navbar-brand me-lg-5" src="/assets/img/duck_head.svg" alt="DuckStation">
 					<div class="collapse navbar-collapse order-3 order-md-0" id="navbarSupportedContent">
 						<ul class="navbar-nav">
 							<li class="nav-item">
-								<a class="nav-link" aria-current="page" href="index.html">
+								<a class="nav-link" aria-current="page" href="/index.html">
 									<span data-text="home">Home</span>
 									<i class="bi bi-house-door"></i>
 								</a>
@@ -33,7 +33,7 @@
 									<i class="bi bi-arrow-down-circle"></i>
 								</a>
 								<ul class="dropdown-menu bg-transparent  border-white">
-									<li><a class="dropdown-item" href="windl.html">Windows</a></li>
+									<li><a class="dropdown-item" href="/windl.html">Windows</a></li>
 									<li><a class="dropdown-item" target="_blank"
 											href="https://play.google.com/store/apps/details?id=com.github.stenzek.duckstation&hl=en_AU&gl=US">Android</a>
 									</li>
@@ -68,7 +68,7 @@
 		<main class="main d-flex align-items-center" data-block="404-main">
 			<div class="container">
 				<div class="promo d-flex flex-column flex-md-row justify-content-center align-items-center my-5 gap-20">
-					<img class="promo__img ratio ratio-1x1 rotate-180" src="./assets/img/duck.svg" alt="duckstation_logo">
+					<img class="promo__img ratio ratio-1x1 rotate-180" src="/assets/img/duck.svg" alt="duckstation_logo">
 					<div class="text-center promo__text">
 						<h1 class="promo__header text-white fw-bold" data-text="header">Uh Oh, 404!</h1>
 						<hr class="mx-auto w-85" />
@@ -76,7 +76,7 @@
 							<p data-text="descr_1">Ducko doesn't know how you got here.</p>
 							<p data-text="descr_2" class="mb-5">But he recommends starting over again from the Home Page.</p>
 						</div>
-						<a class="btn btn-outline-light btn-xl" data-text="home-btn" role="button" href="index.html">Return Home</a>
+						<a class="btn btn-outline-light btn-xl" data-text="home-btn" role="button" href="/index.html">Return Home</a>
 					</div>
 				</div>
 			</div>
@@ -94,7 +94,7 @@
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
 		integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous">
 		</script>
-	<script src="translation.js"></script>
+	<script src="/translation.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>DuckStation: Fast PS1 Emulator</title>
-	<link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicon32.png">
+	<link rel="icon" type="image/png" sizes="32x32" href="/assets/img/favicon32.png">
 	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
 		integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.2/font/bootstrap-icons.min.css">
-	<link href="styles.css" rel="stylesheet" />
+	<link href="/styles.css" rel="stylesheet" />
 </head>
 
 <body class="h-100">
@@ -17,11 +17,11 @@
 		<header class="header" data-block="header">
 			<nav class="navbar navbar-expand-md fixed-top w-100">
 				<div class="container px-lg-5">
-					<img class="navbar-brand me-lg-5" src="assets/img/duck_head.svg" alt="DuckStation">
+					<img class="navbar-brand me-lg-5" src="/assets/img/duck_head.svg" alt="DuckStation">
 					<div class="collapse navbar-collapse order-3 order-md-0" id="navbarSupportedContent">
 						<ul class="navbar-nav">
 							<li class="nav-item">
-								<a class="nav-link active" aria-current="page" href="index.html">
+								<a class="nav-link active" aria-current="page" href="/index.html">
 									<span data-text="home">Home</span>
 									<i class="bi bi-house-door"></i>
 								</a>
@@ -33,7 +33,7 @@
 									<i class="bi bi-arrow-down-circle"></i>
 								</a>
 								<ul class="dropdown-menu bg-transparent  border-white">
-									<li><a class="dropdown-item" href="windl.html">Windows</a></li>
+									<li><a class="dropdown-item" href="/windl.html">Windows</a></li>
 									<li><a class="dropdown-item" target="_blank"
 											href="https://play.google.com/store/apps/details?id=com.github.stenzek.duckstation&hl=en_AU&gl=US">Android</a>
 									</li>
@@ -68,7 +68,7 @@
 		<main class="main d-flex align-items-center" data-block="index-main">
 			<div class="container">
 				<div class="promo d-flex flex-column flex-md-row justify-content-center align-items-center my-5 gap-20">
-					<img class="promo__img ratio ratio-1x1" src="./assets/img/duck.svg" alt="duckstation_logo">
+					<img class="promo__img ratio ratio-1x1" src="/assets/img/duck.svg" alt="duckstation_logo">
 					<div class="text-center promo__text">
 						<h1 class="promo__header text-white fw-bold">DuckStation</h1>
 						<hr class="mx-auto w-85" />
@@ -77,7 +77,7 @@
 							<p data-text="descr_2" class="mb-5">Download DuckStation current version:</p>
 						</div>
 						<div class="d-flex flex-wrap justify-content-center gap-10">
-							<a class="btn btn-outline-light btn-xl" role="button" href="windl.html">Windows</a>
+							<a class="btn btn-outline-light btn-xl" role="button" href="/windl.html">Windows</a>
 							<a class="btn btn-outline-light btn-xl" target="_blank" role="button"
 								href="https://play.google.com/store/apps/details?id=com.github.stenzek.duckstation&hl=en_AU&gl=US">Android</a>
 							<a data-text="platforms" class="btn btn-outline-light btn-xl" target="_blank" role="button"
@@ -100,7 +100,7 @@
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
 		integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous">
 		</script>
-	<script src="translation.js"></script>
+	<script src="/translation.js"></script>
 </body>
 
 </html>

--- a/translation.js
+++ b/translation.js
@@ -13,7 +13,7 @@ window.addEventListener("DOMContentLoaded", () => {
             callback(cachedData);
             return;
         }
-        fetch("translation.json")
+        fetch("/translation.json")
             .then((response) => {
                 if (!response.ok) throw new Error("JSON Download error");
                 return response.json();

--- a/windl.html
+++ b/windl.html
@@ -5,11 +5,11 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>DuckStation: Download Windows</title>
-	<link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicon32.png">
+	<link rel="icon" type="image/png" sizes="32x32" href="/assets/img/favicon32.png">
 	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
 		integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.2/font/bootstrap-icons.min.css">
-	<link href="styles.css" rel="stylesheet" />
+	<link href="/styles.css" rel="stylesheet" />
 </head>
 
 <body class="h-100">
@@ -17,11 +17,11 @@
 		<header class="header" data-block="header">
 			<nav class="navbar navbar-expand-md fixed-top w-100">
 				<div class="container px-lg-5">
-					<img class="navbar-brand me-lg-5" src="assets/img/duck_head.svg" alt="DuckStation">
+					<img class="navbar-brand me-lg-5" src="/assets/img/duck_head.svg" alt="DuckStation">
 					<div class="collapse navbar-collapse order-3 order-md-0" id="navbarSupportedContent">
 						<ul class="navbar-nav">
 							<li class="nav-item">
-								<a class="nav-link" aria-current="page" href="index.html">
+								<a class="nav-link" aria-current="page" href="/index.html">
 									<span data-text="home">Home</span>
 									<i class="bi bi-house-door"></i>
 								</a>
@@ -33,7 +33,7 @@
 									<i class="bi bi-arrow-down-circle"></i>
 								</a>
 								<ul class="dropdown-menu bg-transparent  border-white">
-									<li><a class="dropdown-item active" href="windl.html">Windows</a></li>
+									<li><a class="dropdown-item active" href="/windl.html">Windows</a></li>
 									<li><a class="dropdown-item" target="_blank"
 											href="https://play.google.com/store/apps/details?id=com.github.stenzek.duckstation&hl=en_AU&gl=US">Android</a>
 									</li>
@@ -100,7 +100,7 @@
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
 		integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous">
 		</script>
-	<script src="translation.js"></script>
+	<script src="/translation.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

Fixes broken asset loading on nested routes by converting local asset/page references to root-relative paths.

This updates relative paths across the site, including:

- HTML asset references (`src`, `href`)
- Internal page, script, stylesheet links
- `translation.js` fetch path

**Fixes #9**

This was especially visible on the custom `404.html` page when accessed through nested invalid routes.

## Changes

- Converted local asset references to root-relative paths (`/assets/...`)
- Converted internal navigation links to root-relative paths
- Updated `translation.js` to fetch `/translation.json`

## Verification

- Verified locally by simulating nested invalid routes
- Verified on the deployed site by inspecting and modifying paths in-browser using DevTools

After the changes, CSS, images, scripts, and translations load correctly regardless of route depth.